### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   # Not on master


### PR DESCRIPTION
Potential fix for [https://github.com/Nexusmeister/NexGrades/security/code-scanning/2](https://github.com/Nexusmeister/NexGrades/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block for the `GITHUB_TOKEN`, either at the workflow root (applies to all jobs) or per job, granting only what the workflow needs. This workflow only reads repository contents (checkout, restore, build, test) and does not need to write to the repo or other resources, so `contents: read` is sufficient.

The best way to fix this, without changing existing functionality, is to add a single `permissions` block at the top level of `.github/workflows/ci.yml`, right after the `name:` (or after the `on:` block) so that it applies to all jobs (`test` and `build`). Set it to `contents: read`, which matches CodeQL’s suggested minimal starting point and is adequate for `actions/checkout` and typical read-only CI tasks.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a root-level `permissions:` mapping, e.g. between `name: CI` (line 1) and `on:` (line 3).
- Indent properly according to YAML syntax.
No additional methods, imports, or definitions are required, as this is purely a configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
